### PR TITLE
release/2.5.1

### DIFF
--- a/includes/core/admin/pages/class-system-status.php
+++ b/includes/core/admin/pages/class-system-status.php
@@ -180,6 +180,47 @@ class System_Status extends Admin_Page {
 						'result_export' => $test_or_live_mode,
 					);
 
+					// Pro only.
+					//
+					// @todo Add via filter.
+					if ( class_exists( 'SimplePay\Pro\SimplePayPro' ) ) {
+						$livemode = ! simpay_is_test_mode();
+						$db       = new \SimplePay\Pro\Webhooks\Database\Query();
+
+						$webhook = $db->query(
+							array(
+								'number'   => 1,
+								'livemode' => $livemode,
+							)
+						);
+
+						$sections['simpay']['webhook_last'] = array(
+							'label'         => __( 'Most Recent Webhook Event', 'stripe' ),
+							'label_export'  => 'Most Recent Webhook Event',
+							'result'        => ! empty( $webhook ) ? current( $webhook )->date_created : 'None',
+							'result_export' => ! empty( $webhook ) ? current( $webhook )->date_created : 'None',
+						);
+
+						$settings = get_option( 'simpay_settings_keys' );
+
+						if ( false === $livemode ) {
+							$endpoint_secret = isset( $settings['test_keys']['endpoint_secret'] )
+								? $settings['test_keys']['endpoint_secret']
+								: '';
+						} else {
+							$endpoint_secret = isset( $settings['live_keys']['endpoint_secret'] )
+								? $settings['live_keys']['endpoint_secret']
+								: '';
+						}
+
+						$sections['simpay']['webhook_secret'] = array(
+							'label'         => __( 'Webhook Secret', 'stripe' ),
+							'label_export'  => 'Webhook Secret', 
+							'result'        => ! empty( $endpoint_secret ) ? 'Yes' : 'No',
+							'result_export' => ! empty( $endpoint_secret ) ? 'Yes' : 'No',
+						);
+					}
+
 					/**
 					 * WordPress Installation
 					 * ======================

--- a/includes/core/class-simplepay.php
+++ b/includes/core/class-simplepay.php
@@ -112,6 +112,7 @@ final class SimplePay {
 		require_once( SIMPLE_PAY_INC . 'core/post-types/simple-pay/meta.php' );
 
 		// Load core shared back-end & front-end functions.
+		require_once( SIMPLE_PAY_INC . 'core/utils/functions.php' );
 		require_once( SIMPLE_PAY_INC . 'core/utils/exceptions.php' );
 		require_once( SIMPLE_PAY_INC . 'core/utils/collections.php' );
 		require_once( SIMPLE_PAY_INC . 'core/functions/template.php' );
@@ -148,6 +149,10 @@ final class SimplePay {
 		$cron = new Cron();
 		$cron->init();
 		$cron->schedule_events();
+
+		// Rate Limiting.
+		$rate_limiting = new Utils\Rate_Limiting();
+		$rate_limiting->init();
 
 		$this->objects = new Objects();
 

--- a/includes/core/payments/payment-confirmation-template-tags.php
+++ b/includes/core/payments/payment-confirmation-template-tags.php
@@ -309,8 +309,11 @@ function charge_date( $value, $payment_confirmation_data ) {
 	// Assume and use the first charge in the list.
 	$first_charge = current( $charges->data );
 
-	// Localize format.
-	$value = date_i18n( get_option( 'date_format' ), $first_charge->created );
+	// Localize to current timezone and formatting.
+	$value = get_date_from_gmt(
+		date( 'Y-m-d H:i:s', $first_charge->created ),
+		get_option( 'date_format' )
+	);
 
 	/**
 	 * @deprecated 3.6.0

--- a/includes/core/rest-api/v2/class-checkout-session-controller.php
+++ b/includes/core/rest-api/v2/class-checkout-session-controller.php
@@ -71,6 +71,21 @@ class Checkout_Session_Controller extends Controller {
 	 * @return bool True with a valid nonce.
 	 */
 	public function create_item_permissions_check( $request ) {
+		$has_exceeded_rate_limit = false;
+
+		/** This filter is documented in includes/core/rest-api/class-customer-controller.php */
+		$has_exceeded_rate_limit = apply_filters( 'simpay_has_exceeded_rate_limit', $has_exceeded_rate_limit );
+
+		if ( true === $has_exceeded_rate_limit ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you have made too many requests. Please try again later.', 'stripe' ),
+				array(
+					'status' => rest_authorization_required_code()
+				)
+			);
+		}
+
 		$form_values = $request['form_values'];
 
 		if ( ! isset( $form_values['_wpnonce'] ) || ! wp_verify_nonce( $form_values['_wpnonce'], 'simpay_payment_form' ) ) {

--- a/includes/core/rest-api/v2/class-customer-controller.php
+++ b/includes/core/rest-api/v2/class-customer-controller.php
@@ -69,6 +69,27 @@ class Customer_Controller extends Controller {
 	 * @return bool
 	 */
 	public function create_item_permissions_check( $request ) {
+		$has_exceeded_rate_limit = false;
+
+		/**
+		 * Filters if the current IP address has exceeded the rate limit.
+		 *
+		 * @since 3.9.5
+		 *
+		 * @param bool $has_exceeded_rate_limit
+		 */
+		$has_exceeded_rate_limit = apply_filters( 'simpay_has_exceeded_rate_limit', $has_exceeded_rate_limit );
+
+		if ( true === $has_exceeded_rate_limit ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you have made too many requests. Please try again later.', 'stripe' ),
+				array(
+					'status' => rest_authorization_required_code()
+				)
+			);
+		}
+
 		$form_values = $request['form_values'];
 
 		if ( ! isset( $form_values['_wpnonce'] ) || ! wp_verify_nonce( $form_values['_wpnonce'], 'simpay_payment_form' ) ) {

--- a/includes/core/rest-api/v2/class-paymentintent-controller.php
+++ b/includes/core/rest-api/v2/class-paymentintent-controller.php
@@ -86,6 +86,21 @@ class PaymentIntent_Controller extends Controller {
 	 * @return bool True with a valid nonce.
 	 */
 	public function create_item_permissions_check( $request ) {
+		$has_exceeded_rate_limit = false;
+
+		/** This filter is documented in includes/core/rest-api/class-customer-controller.php */
+		$has_exceeded_rate_limit = apply_filters( 'simpay_has_exceeded_rate_limit', $has_exceeded_rate_limit );
+
+		if ( true === $has_exceeded_rate_limit ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you have made too many requests. Please try again later.', 'stripe' ),
+				array(
+					'status' => rest_authorization_required_code()
+				)
+			);
+		}
+
 		$form_values = $request['form_values'];
 
 		if ( ! isset( $form_values['_wpnonce'] ) || ! wp_verify_nonce( $form_values['_wpnonce'], 'simpay_payment_form' ) ) {

--- a/includes/core/utils/class-rate-limiting.php
+++ b/includes/core/utils/class-rate-limiting.php
@@ -1,0 +1,328 @@
+<?php
+/**
+ * Rate Limiting
+ *
+ * @package SimplePay\Core\Utils
+ * @copyright Copyright (c) 2020, Sandhills Development, LLC
+ * @license http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since 3.9.5
+ */
+
+namespace SimplePay\Core\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Rate Limiting
+ *
+ * @since 3.9.5
+ */
+class Rate_Limiting {
+
+	/**
+	 * Is the file writable.
+	 *
+	 * @var bool
+	 */
+	public $is_writable = true;
+
+	/**
+	 * The rate limiting log file.
+	 *
+	 * @var string
+	 */
+	private $filename = '';
+
+	/**
+	 * The file path to the log file.
+	 *
+	 * @var string
+	 */
+	private $file = '';
+
+	/**
+	 * Register any actions we need to use.
+	 *
+	 * @since 3.9.5
+	 */
+	public function init() {
+
+		// Setup the log file.
+		add_action( 'plugins_loaded', array( $this, 'setup_log_file' ), 11 );
+
+		// Determines if the current rate limit has been exceeded.
+		//
+		// Note: Using this inside REST API permission checks means that it is called an additional
+		//       time for the first permission check which is why the default is somewhat high.
+		//
+		//       https://github.com/WP-API/WP-API/issues/2400#issuecomment-202620551
+		add_filter( 'simpay_has_exceeded_rate_limit', array( $this, 'has_hit_limit' ) );
+	}
+
+	/**
+	 * Sets up the log file if it is writable
+	 *
+	 * @since 3.9.5
+	 */
+	public function setup_log_file() {
+		$upload_dir       = wp_upload_dir();
+		$this->filename   = wp_hash( home_url( '/' ) ) . '-wpsp-rate-limiting.log';
+		$this->file       = trailingslashit( $upload_dir['basedir'] ) . $this->filename;
+
+		if ( ! is_writeable( $upload_dir['basedir'] ) ) {
+			$this->is_writable = false;
+		}
+	}
+
+	/**
+	 * Checks if the current IP address has hit the rate limit.
+	 *
+	 * @since 3.9.5
+	 *
+	 * @return bool
+	 */
+	public function has_hit_limit() {
+		if ( ! $this->rate_limiting_enabled() ) {
+			return false;
+		}
+
+		$count = $this->increment_rate_limit_count();
+
+		$blocking_id = $this->get_rate_limit_id();
+		$entry       = $this->get_rate_limiting_entry( $blocking_id );
+		$expiration  = ! empty( $entry['timeout'] ) ? $entry['timeout'] : 0;
+
+		// Previous request limit expiration has passed. Start fresh.
+		if ( $expiration < time() ) {
+			$this->remove_log_entry( $this->get_rate_limit_id() );
+			return false;
+		}
+
+		$max_rate_count = 30;
+
+		/**
+		 * Filters the number of times the endpoint can be hit within the specified time period (1 hour).
+		 *
+		 * @since 3.9.5
+		 *
+		 * @param bool $max_error_count The maximum failed checkouts before blocking future attempts. Default 5.
+		 */
+		$max_rate_count = apply_filters( 'simpay_rate_limiting_max_rate_count', $max_rate_count );
+
+		return $count >= $max_rate_count;
+	}
+
+	/**
+	 * Remove an entry from the rate limiting log.
+	 *
+	 * @since 3.9.5
+	 *
+	 * @param string $blocking_id The blocking ID for the rate limiting.
+	 */
+	public function remove_log_entry( $blocking_id = '' ) {
+		$current_logs = $this->get_decoded_file();
+		unset( $current_logs[ $blocking_id ] );
+
+		$this->write_to_log( $current_logs );
+	}
+
+	/**
+	 * Get a specific entry from the rate limiting log.
+	 *
+	 * @since 3.9.5
+	 *
+	 * @param string $blocking_id The blocking ID to get the entry for.
+	 * @return array
+	 */
+	public function get_rate_limiting_entry( $blocking_id = '' ) {
+		$current_logs = $this->get_decoded_file();
+		$entry = array();
+
+		if ( array_key_exists( $blocking_id, $current_logs ) ) {
+			$entry = $current_logs[ $blocking_id ];
+		}
+
+		return $entry;
+	}
+
+
+	/**
+	 * Retrieves the number of times an IP address has made requests.
+	 *
+	 * @since 3.9.5
+	 *
+	 * @return int
+	 */
+	public function get_rate_count() {
+		$blocking_id = $this->get_rate_limit_id();
+		$count       = 0;
+
+		$current_blocks = $this->get_decoded_file();
+
+		if ( array_key_exists( $blocking_id, $current_blocks ) ) {
+			$count = $current_blocks[ $blocking_id ]['count'];
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Increments the rate limit counter.
+	 *
+	 * @since 3.9.5
+	 *
+	 * @return int
+	 */
+	public function increment_rate_limit_count() {
+		$current_count = $this->get_rate_count();
+		$blocking_id   = $this->get_rate_limit_id();
+
+		if ( empty( $current_count ) ) {
+			$current_count = 1;
+		} else {
+			$current_count++;
+		}
+
+		$this->update_rate_limiting_count( $blocking_id, $current_count );
+
+		return absint( $current_count );
+	}
+
+	/**
+	 * Update an entry in the rate limiting array.
+	 *
+	 * @since 3.9.5
+	 *
+	 * @param string $blocking_id   The blocking ID.
+	 * @param int    $current_count The count to update to.
+	 */
+	protected function update_rate_limiting_count( $blocking_id = '', $current_count = 0 ) {
+		$expiration_in_seconds = HOUR_IN_SECONDS;
+
+		/**
+		 * Filters the length of time before rate limits are reset.
+		 *
+		 * @since 3.9.5
+		 *
+		 * @param int $expiration_in_seconds The length in seconds before rate limit counts are reset. Default 60.
+		 */
+		$expiration_in_seconds = apply_filters( 'simpay_rate_limiting_timeout', $expiration_in_seconds );
+
+		$current_log = $this->get_decoded_file();
+
+		// New entry, add expiration time.
+		if ( ! isset( $current_log[ $blocking_id ] ) ) {
+			$current_log[ $blocking_id ]['timeout'] = time() + $expiration_in_seconds;
+		}
+
+		// Always increment count.
+		$current_log[ $blocking_id ]['count'] = $current_count;
+
+		$this->write_to_log( $current_log );
+	}
+
+	/**
+	 * Determines if we should use rate limiting.
+	 *
+	 * @since 3.9.5
+	 *
+	 * @return bool
+	 */
+	public function rate_limiting_enabled() {
+		$rate_limiting_enabled = true;
+
+		/**
+		 * Filters if rate limiting should be enabled.
+		 *
+		 * @since 3.9.5
+		 *
+		 * @param bool $rate_limiting_enabled Enables or disables rate limiting. Default true, enabled.
+		 */
+		$rate_limiting_enabled = apply_filters( 'simpay_rate_limiting_enabled', true );
+
+		return true === $rate_limiting_enabled;
+	}
+
+	/**
+	 * Generates the rate limiting tracking ID.
+	 *
+	 * @since 3.9.5
+	 *
+	 * @return string
+	 */
+	public function get_rate_limit_id() {
+		return get_current_ip_address();
+	}
+
+	/**
+	 * Retrieve the log data
+	 *
+	 * @since 3.9.5
+	 * @return string
+	 */
+	protected function get_file_contents() {
+		return $this->get_file();
+	}
+
+	/**
+	 * Get the decoded array of rate limiting from the log file.
+	 *
+	 * @since 3.9.5
+	 *
+	 * @return array
+	 */
+	protected function get_decoded_file() {
+		$decoded_contents = json_decode( $this->get_file_contents(), true );
+
+		if ( is_null( $decoded_contents ) ) {
+			$decoded_contents = array();
+		}
+
+		return (array) $decoded_contents;
+	}
+
+	/**
+	 * Retrieve the file data is written to
+	 *
+	 * @since 3.9.5
+	 *
+	 * @return string
+	 */
+	protected function get_file() {
+		$file = json_encode( array() );
+
+		if ( @file_exists( $this->file ) ) {
+
+			if ( ! is_writeable( $this->file ) ) {
+				$this->is_writable = false;
+			}
+
+			$file = @file_get_contents( $this->file );
+		} else {
+
+			@file_put_contents( $this->file, $file );
+			@chmod( $this->file, 0664 );
+		}
+
+		return $file;
+	}
+
+	/**
+	 * Write the log message
+	 *
+	 * @since 3.9.5
+	 *
+	 * @param array $content The content of the rate limiting.
+	 *
+	 * @return void
+	 */
+	public function write_to_log( $content = array() ) {
+		$content = json_encode( $content );
+
+		if ( $this->is_writable ) {
+			@file_put_contents( $this->file, $content );
+		}
+	}
+}

--- a/includes/core/utils/functions.php
+++ b/includes/core/utils/functions.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Utils: functions
+ *
+ * @package SimplePay\Core\Utils
+ * @copyright Copyright (c) 2020, Sandhills Development, LLC
+ * @license http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since 3.9.5
+ */
+
+namespace SimplePay\Core\Utils;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+
+/**
+ * Retrieves the IP address of the current visitor.
+ *
+ * @since 3.9.5
+ *
+ * @return string $ip User's IP address
+ */
+function get_current_ip_address() {
+	$ip = false;
+
+	if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ) {
+		// Check ip from share internet.
+		$ip = filter_var( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ), FILTER_VALIDATE_IP );
+	} elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+		// To check ip is pass from proxy.
+		// Can include more than 1 ip, first is the public one.
+
+		// WPCS: sanitization ok.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$ips = explode( ',', wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
+
+		if ( is_array( $ips ) ) {
+			$ip = filter_var( $ips[0], FILTER_VALIDATE_IP );
+		}
+	} elseif ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+		$ip = filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_VALIDATE_IP );
+	}
+
+	$ip = false !== $ip ? $ip : '127.0.0.1';
+
+	// Fix potential CSV returned from $_SERVER variables.
+	$ip_array = explode( ',', $ip );
+	$ip_array = array_map( 'trim', $ip_array );
+
+	/**
+	 * Filters the current visitor's IP address.
+	 *
+	 * @since 3.9.5
+	 *
+	 * @param string $ip
+	 */
+	return apply_filters( 'simpay_get_current_ip_address', $ip_array[0] );
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wp-simple-pay-lite",
   "title": "WP Simple Pay Lite for Stripe",
   "description": "Add high conversion Stripe Checkout forms to your WordPress site and start accepting payments in minutes. **Lite Version**",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "GPL-2.0-or-later",
   "homepage": "https://wpsimplepay.com/",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -266,6 +266,11 @@ WP Simple Pay Pro offers on-site payments forms that ensure customers never leav
 
 == Changelog ==
 
+= 2.5.1 - August 26, 2020 =
+
+* New: Add IP-based rate limiting to internal API endpoints.
+* Fix: Ensure {charge-date} Payment Confirmation Template Tag is output in the site's local timezone.
+
 = 2.5.0 - July 30, 2020 =
 
 * New: Add per-form "Test Mode" toggles.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pderksen, spencerfinnell, adamjlea, mordauk, cklosows, sdavis2702,
 Tags: stripe, stripe checkout, stripe payments, payments, credit card payments
 Requires at least: 4.9
 Tested up to: 5.5
-Stable tag: 2.5.0
+Stable tag: 2.5.1
 Requires PHP: 5.6
 License: GPLv2 or later
 

--- a/stripe-checkout.php
+++ b/stripe-checkout.php
@@ -5,7 +5,7 @@
  * Description: Add high conversion Stripe payment forms to your WordPress site in minutes.
  * Author: Sandhills Development, LLC
  * Author URI: https://sandhillsdev.com
- * Version: 2.5.0
+ * Version: 2.5.1
  * Text Domain: stripe
  * Domain Path: /languages
  */
@@ -45,7 +45,7 @@ if ( ! defined( 'SIMPLE_PAY_VERSION' ) ) {
 	//
 	// Lite/Pro-specific.
 	//
-	define( 'SIMPLE_PAY_VERSION', '2.5.0' );
+	define( 'SIMPLE_PAY_VERSION', '2.5.1' );
 
 	if ( ! defined( 'SIMPLE_PAY_PLUGIN_NAME' ) ) {
 		define( 'SIMPLE_PAY_PLUGIN_NAME', 'WP Simple Pay Lite' );


### PR DESCRIPTION
```
* New: Add IP-based rate limiting to internal API endpoints.
* Fix: Ensure {charge-date} Payment Confirmation Template Tag is output in the site's local timezone.
```